### PR TITLE
:sparkles: Check if token is refreshed in middleware

### DIFF
--- a/src/Middleware/CheckTokenAllowedAge.php
+++ b/src/Middleware/CheckTokenAllowedAge.php
@@ -22,9 +22,11 @@ readonly class CheckTokenAllowedAge
         $token = $this->requestAuthenticator->authenticate($request);
         $ageThreshold = Carbon::now()->subMinutes($maxAge);
 
-        if ($token->hasBeenIssuedBefore($ageThreshold)) {
+        $tokenIsRefreshed = $token->claims()->get('refreshed', false);
+
+        if ($token->hasBeenIssuedBefore($ageThreshold) || $tokenIsRefreshed) {
             throw new InvalidAccessTokenException(
-                "The access token cannot be older than {$maxAge} minutes for this request. Please request a new access token to continue.",
+                "The access token cannot be older than {$maxAge} minutes or be refreshed using a refresh token. Please request a new access token to continue.",
             );
         }
 


### PR DESCRIPTION
## Changes
- The CheckTokenAllowedAge middleware should consider tokens as result of refresh token grant as not-fresh. We check the custom `refreshed` claim to accomplish this.